### PR TITLE
publish: update metadata

### DIFF
--- a/src/dataverk/dataverk.py
+++ b/src/dataverk/dataverk.py
@@ -61,13 +61,13 @@ class Dataverk:
 
         return conn.persist_pandas_df(table, schema=schema, df=df, if_exists=if_exists)
 
-    def publish(self, datapackage):
+    def publish(self, datapackage, csv_sep: str=";"):
         resources = datapackage.resources
         metadata = datapackage.datapackage_metadata
 
         # Publish resources to buckets
         package_publisher = PackagePublisher(datapackage_metadata=metadata, settings_store=self._context.settings, env_store={})
-        package_publisher.publish(resources=resources)
+        package_publisher.publish(resources=resources, csv_sep=csv_sep)
 
         # Publish metadata to elastic search
         es_conn = ElasticsearchConnector(self._context.settings)

--- a/src/dataverk/package_publisher.py
+++ b/src/dataverk/package_publisher.py
@@ -43,12 +43,13 @@ class PackagePublisher:
     def upload_to_storage_bucket(
         datapackage_metadata,
         resources,
+        csv_sep: str,
         conn: BucketStorageConnector,
         datapackage_key_prefix: str,
-        csv_sep: str=";"
     ) -> None:
         """ Publish data to bucket storage.
 
+        :param csv_sep: csv separator
         :param resources: datapackage data to be published
         :param datapackage_metadata: metadata assosciated with the datapackage
         :param conn: BucketStorageConnector object: the connection object for chosen bucket storage.

--- a/src/dataverk/package_publisher.py
+++ b/src/dataverk/package_publisher.py
@@ -13,9 +13,9 @@ class PackagePublisher:
     ):
         self._settings_store = settings_store
         self._env_store = env_store
-        self.datapackage_metadata = datapackage_metadata
+        self._datapackage_metadata = datapackage_metadata
 
-    def publish(self, resources):
+    def publish(self, resources, csv_sep):
         """ - Iterates through all bucket storage connections in the settings.json file and publishes the datapackage
             - Updates ES index with metadata for the datapackage
 
@@ -25,17 +25,18 @@ class PackagePublisher:
         for bucket_type in self._settings_store["bucket_storage_connections"]:
             if self._is_publish_set(bucket_type=bucket_type):
                 self.upload_to_storage_bucket(
-                    datapackage_metadata=self.datapackage_metadata,
+                    datapackage_metadata=self._datapackage_metadata,
                     conn=get_storage_connector(
                         bucket_type=BucketType(bucket_type),
-                        bucket_name=self.datapackage_metadata.get("bucket_name"),
+                        bucket_name=self._datapackage_metadata.get("bucket"),
                         settings=self._settings_store,
                         encrypted=False,
                     ),
                     datapackage_key_prefix=self._datapackage_key_prefix(
-                        self.datapackage_metadata.get("name")
+                        self._datapackage_metadata.get("name")
                     ),
                     resources=resources,
+                    csv_sep=csv_sep
                 )
 
     @staticmethod
@@ -44,6 +45,7 @@ class PackagePublisher:
         resources,
         conn: BucketStorageConnector,
         datapackage_key_prefix: str,
+        csv_sep: str=";"
     ) -> None:
         """ Publish data to bucket storage.
 
@@ -61,7 +63,7 @@ class PackagePublisher:
                 "json",
             )
             for filename, df in resources.items():
-                csv_string = df.to_csv(sep=",", encoding="utf-8")
+                csv_string = df.to_csv(sep=csv_sep, encoding="utf-8")
                 conn.write(
                     csv_string, f"{datapackage_key_prefix}resources/{filename}", "csv"
                 )

--- a/tests/dataverk/test_packagePublisher.py
+++ b/tests/dataverk/test_packagePublisher.py
@@ -17,8 +17,8 @@ class TestPackagePublisher(TestCase):
 
     def test_publish(self):
         pp = PackagePublisher(settings_store=MOCK_SETTINGS, datapackage_metadata=MOCK_METADATA, env_store=MOCK_ENVSTORE)
-        pp.publish(["resource1, resource2"])
+        pp.publish(["resource1, resource2"], csv_sep=";")
 
     def test_upload_to_storage_bucket(self):
         pp = PackagePublisher(settings_store=MOCK_SETTINGS, datapackage_metadata=MOCK_METADATA, env_store=MOCK_ENVSTORE)
-        pp.upload_to_storage_bucket(MOCK_METADATA, [], None, "prefix")
+        pp.upload_to_storage_bucket(MOCK_METADATA, [], csv_sep=";", conn=None, datapackage_key_prefix="prefix")


### PR DESCRIPTION
1. Endret metadata krav for Datapackage klasse. Krav til at følgende er angitt i metadataobjektet:
-  store (lagring: google_cloud, dataverk_s3 eller github)
-  name (datapakkenavn)
-  bucket (navn på bucket)

valgfrie parametere: title, keywords, accessRights, description, publisher,user, package, geo, provenance,id, repo

2. satte csv separator til å være en valgfri input parameter til dv.publish metoden (default separator er semikolon)