### PR TITLE
correct format for zipped remote resources in metadata

### DIFF
--- a/src/dataverk/datapackage.py
+++ b/src/dataverk/datapackage.py
@@ -175,7 +175,7 @@ class Datapackage:
 
         resource = parsed_url.path.split('/')[-1]
         resource_name_and_format = resource.split('.', 1)
-        return resource_name_and_format[0], resource_name_and_format[1].split('.')[0]
+        return resource_name_and_format[0], resource_name_and_format[1]
 
     @staticmethod
     def _verify_add_resource_input_types(df, dataset_name, dataset_description):

--- a/tests/dataverk/test_datapackage.py
+++ b/tests/dataverk/test_datapackage.py
@@ -88,9 +88,9 @@ class TestMethodReturnValues(unittest.TestCase):
 
     def test__resource_name_and_type_from_url_zipped(self):
         resource_name_in = "resource"
-        resource_fmt_in = "csv"
+        resource_fmt_in = "csv.gz"
         resource_url = f"https://remote.storage.location.com/bucket/" \
-                       f"datapackage/resources/{resource_name_in}.{resource_fmt_in}.gz"
+                       f"datapackage/resources/{resource_name_in}.{resource_fmt_in}"
         resource_name, resource_fmt = Datapackage._resource_name_and_type_from_url(resource_url)
         self.assertEqual(resource_name_in, resource_name)
         self.assertEqual(resource_fmt_in, resource_fmt)


### PR DESCRIPTION
- bugfix: .gz file extension for remote resources in metadata